### PR TITLE
workaround RPM build failure

### DIFF
--- a/packaging/rpm/systemd.spec
+++ b/packaging/rpm/systemd.spec
@@ -456,7 +456,9 @@ EOF
 
 #############################################################################################
 
-%include %{SOURCE1}
+# workaround https://github.com/packit-service/packit-service/issues/138
+# obviously this will break all the tests
+# %%include %%{SOURCE1}
 
 %pre
 getent group cdrom &>/dev/null || groupadd -r -g 11 cdrom &>/dev/null || :


### PR DESCRIPTION
with this change, systemd can be built in copr but the resulting rpm is not functional (see the change)